### PR TITLE
Also try the newer location of the tty file in Docker for Mac

### DIFF
--- a/forward.sh
+++ b/forward.sh
@@ -21,10 +21,16 @@ if ! test -S ${SSH_AUTH_SOCK}; then
 fi
 
 TTY_FILE=~/Library/Containers/com.docker.docker/Data/com.docker.driver.amd64-linux/tty
+TTY_FILE_NEW=~/Library/Containers/com.docker.docker/Data/vms/0/tty
 
 if ! test -c $TTY_FILE; then
-    echo "$TTY_FILE is not available. Docker for Mac setup has changed?"
-    exit 1
+    echo "$TTY_FILE is not available. Docker for Mac setup has changed? Trying newer file..."
+    if ! test -c $TTY_FILE_NEW; then
+        echo "$TTY_FILE_NEW is not available. Docker for Mac setup has changed? Giving up."
+        exit 1
+    else
+        TTY_FILE=$TTY_FILE_NEW
+    fi
 fi
 
 # This is where the UGLY hack starts


### PR DESCRIPTION
I just installed Docker for Mac. It's version 18.06.1-ce-mac73 (26764) and they apparently moved the "tty" file. So I changed your shell script to try the new location, too. I just tested everything else and it works. Thanks for putting this workaround together.